### PR TITLE
Allow values to contain equals signs

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function parse_keypair (keypair){
 
     key = desktop_entries_mapping[key] != undefined ? desktop_entries_mapping[key] : key;
 
-    var value = keypair.split('=')[1];
+    var value = keypair.substring(keypair.indexOf('=') + 1);
     if(value != undefined){
         if(value.indexOf(';') > -1){
             value = value.split(';');


### PR DESCRIPTION
The current implementation only uses the part of the value before the first equals sign (if it contains equal signs).

Here are some examples:
* `mpv.desktop` on Debian: `Exec=mpv --player-operation-mode=pseudo-gui -- %U`
* `software-properties-driver.desktop` on Ubuntu: `Exec=/usr/bin/software-properties-gtk --open-tab=4`
* `gimp.desktop` on Debian: `Name[eo]=Bildmanipulilo (GIMP = GNU Image Manipulation Program)`